### PR TITLE
Do not crash when pressing disabled ToolStrip buttons

### DIFF
--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Controls/ToolStrip.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Controls/ToolStrip.cs
@@ -223,7 +223,10 @@ namespace Kuriimu2.EtoForms.Controls
 
         private void ButtonToolStripItem_MouseUp(object sender, MouseEventArgs e)
         {
-            Command?.Execute();
+            if (_isEnabled)
+            {
+                Command?.Execute();
+            }
 
             _isClicked = false;
             ParentToolStrip?.Invalidate();


### PR DESCRIPTION
Obligatory title says it all :)

I'd love to add a "unsupported operation" message, but it looks like `_formInfo.FormCommunicator.ReportStatus` is not available in this section :(