### PR TITLE
Move 'Hashes' and 'Raw Image Viewer' under 'Tools' submenu

### DIFF
--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/MainForm.eto.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/MainForm.eto.cs
@@ -84,15 +84,48 @@ namespace Kuriimu2.EtoForms.Forms
             {
                 Items =
                 {
-                    new ButtonMenuItem { Text = "File", Items = { openFileCommand, openFileWithCommand, new SeparatorMenuItem(), saveAllFileCommand } },
-                    new ButtonMenuItem { Text = "Tools", Items = { openBatchExtractorCommand, openBatchInjectorCommand, openTextSequenceSearcherCommand } },
-                    new ButtonMenuItem(openHashcommand),
-                    new ButtonMenuItem { Text = "Ciphers", Items = { openEncryptionCommand, openDecryptionCommand } },
-                    new ButtonMenuItem { Text = "Compressions", Items = { openDecompressionCommand, openCompressionCommand } },
-                    new ButtonMenuItem(openRawImageViewerCommand),
+                    new ButtonMenuItem { Text = "File", Items =
+                    {
+                        openFileCommand, 
+                        openFileWithCommand, 
+                        new SeparatorMenuItem(), 
+                        saveAllFileCommand
+                    } },
+                    
+                    new ButtonMenuItem { Text = "Tools", Items =
+                    {
+                        openBatchExtractorCommand,
+                        openBatchInjectorCommand,
+                        openTextSequenceSearcherCommand,
+                        openHashcommand,
+                        openRawImageViewerCommand,
+                    } },
+                    
+                    new ButtonMenuItem { Text = "Ciphers", Items =
+                    {
+                        openEncryptionCommand, 
+                        openDecryptionCommand
+                    } },
+                    
+                    new ButtonMenuItem { Text = "Compressions", Items =
+                    {
+                        openDecompressionCommand, 
+                        openCompressionCommand
+                    } },
+                    
                     //new ButtonMenuItem(openImageTranscoderCommand),
-                    new ButtonMenuItem { Text = "Settings", Items = { new CheckMenuItem { Text = "Include Developer Builds", Checked = Settings.Default.IncludeDevBuilds, Command = includeDevBuildCommand } } }
+                    
+                    new ButtonMenuItem { Text = "Settings", Items =
+                    {
+                        new CheckMenuItem
+                        {
+                            Text = "Include Developer Builds", 
+                            Checked = Settings.Default.IncludeDevBuilds, 
+                            Command = includeDevBuildCommand
+                        }
+                    } }
                 },
+                
                 AboutItem = openAboutCommand
             };
 


### PR DESCRIPTION
Incumbent "title says it all" 🙃

Since these entry directly correspond to an action, and because those actions are tools, I think they are a better fit inside the Tools submenu.
I also took the liberty to add some linebreaks to make the file a little more readable (at least in my opinion).