### PR TITLE
Re-implement ToolStrip as a container of Drawable ToolStripItems (tooltips!)

### DIFF
--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Wpf/Program.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Wpf/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
-using Eto.Forms;
+using System.Windows;
+using System.Windows.Controls;
 using Kuriimu2.EtoForms.Forms;
+using Application = Eto.Forms.Application;
 
 namespace Kuriimu2.EtoForms.Wpf
 {
@@ -9,6 +11,9 @@ namespace Kuriimu2.EtoForms.Wpf
         [STAThread]
         public static void Main(string[] args)
         {
+            // https://stackoverflow.com/a/39348804/10434371
+            ToolTipService.ShowOnDisabledProperty.OverrideMetadata(typeof(FrameworkElement), new FrameworkPropertyMetadata(true));
+            
             new Application(Eto.Platforms.Wpf).Run(new MainForm());
         }
     }

--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Controls/ToolStrip.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Controls/ToolStrip.cs
@@ -109,6 +109,7 @@ namespace Kuriimu2.EtoForms.Controls
                 return;
 
             var rect = new RectangleF(0, 0, Width, Height);
+            g.PixelOffsetMode = PixelOffsetMode.Half;
 
             // If clicked use darker colors
             if (Enabled && _isClicked)

--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/Formats/ArchiveForm.eto.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/Formats/ArchiveForm.eto.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using Eto.Drawing;
 using Eto.Forms;
 using Kuriimu2.EtoForms.Controls;
@@ -178,6 +178,7 @@ namespace Kuriimu2.EtoForms.Forms.Formats
             searchClearButton = new Button
             {
                 Image = ImageResources.Actions.Clear,
+				ToolTip = "Reset search",
                 Command = searchClearCommand,
                 Size = new Size(22,-1)
             };
@@ -190,31 +191,37 @@ namespace Kuriimu2.EtoForms.Forms.Formats
 
             saveButton = new ButtonToolStripItem
             {
+                ToolTip = "Save",
                 Command = saveCommand,
             };
 
             saveAsButton = new ButtonToolStripItem
             {
+                ToolTip = "Save As",
                 Command = saveAsCommand,
             };
 
             extractButton = new ButtonToolStripItem
             {
+                ToolTip = "Extract file(s)",
                 Command = extractFileCommand,
             };
 
             replaceButton = new ButtonToolStripItem
             {
+                ToolTip = "Replace file(s)",
                 Command = replaceFileCommand,
             };
 
             renameButton = new ButtonToolStripItem
             {
+                ToolTip = "Rename file",
                 Command = renameFileCommand,
             };
 
             deleteButton = new ButtonToolStripItem
             {
+                ToolTip = "Delete file",
                 Command = deleteFileCommand,
             };
 

--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/Formats/ArchiveForm.eto.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/Formats/ArchiveForm.eto.cs
@@ -178,7 +178,7 @@ namespace Kuriimu2.EtoForms.Forms.Formats
             searchClearButton = new Button
             {
                 Image = ImageResources.Actions.Clear,
-				ToolTip = "Reset search",
+                ToolTip = "Reset search",
                 Command = searchClearCommand,
                 Size = new Size(22,-1)
             };
@@ -233,7 +233,7 @@ namespace Kuriimu2.EtoForms.Forms.Formats
 
             var archiveToolStrip = new ToolStrip
             {
-                BackgroundColor = KnownColors.White,
+                Padding = 3,
                 Items =
                 {
                     saveButton,
@@ -243,7 +243,7 @@ namespace Kuriimu2.EtoForms.Forms.Formats
 
             var mainContent = new TableLayout
             {
-                Spacing=new Size(3,3),
+                Spacing = new Size(3,3),
                 Rows =
                 {
                     // Searchbar and file toolstrip
@@ -266,8 +266,6 @@ namespace Kuriimu2.EtoForms.Forms.Formats
                             // file toolstrip
                             new ToolStrip
                             {
-                                Size = new SizeF(-1, ToolStripItem.Height + 6),
-                                BackgroundColor = KnownColors.White,
                                 Items =
                                 {
                                     extractButton,
@@ -296,7 +294,7 @@ namespace Kuriimu2.EtoForms.Forms.Formats
                 Spacing = new Size(3, 3),
                 Rows =
                 {
-                    new TableRow(new Panel { Content = archiveToolStrip, Size = new Size(-1, (int)ToolStripItem.Height + 6) }),
+                    new TableRow(archiveToolStrip),
                     new TableRow { Cells = { new TableCell(mainContent) { ScaleWidth = true } }, ScaleHeight = true }
                 }
             };

--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/Formats/ImageForm.eto.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/Formats/ImageForm.eto.cs
@@ -97,6 +97,7 @@ namespace Kuriimu2.EtoForms.Forms.Formats
 
             var mainToolStrip = new ToolStrip
             {
+                Padding = 3,
                 Items =
                 {
                     saveButton,
@@ -187,7 +188,7 @@ namespace Kuriimu2.EtoForms.Forms.Formats
             {
                 Rows =
                 {
-                    new TableRow(new Panel { Content = mainToolStrip, Size = new Size(-1, (int)ToolStripItem.Height + 6) }),
+                    new TableRow(mainToolStrip),
                     mainLayout
                 }
             };

--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/Formats/ImageForm.eto.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/Formats/ImageForm.eto.cs
@@ -46,21 +46,25 @@ namespace Kuriimu2.EtoForms.Forms.Formats
 
             saveButton = new ButtonToolStripItem
             {
+                ToolTip = "Save",
                 Command = saveCommand,
             };
 
             saveAsButton = new ButtonToolStripItem
             {
+                ToolTip = "Save As",
                 Command = saveAsCommand,
             };
 
             exportButton = new ButtonToolStripItem
             {
+                ToolTip = "Export image",
                 Command = exportCommand,
             };
 
             importButton = new ButtonToolStripItem
             {
+                ToolTip = "Import image data",
                 Command = importCommand,
             };
 


### PR DESCRIPTION
This refactor gives us three things:
1. Proper tooltip support, which I've immediately made use of.
2. Less code by re-using the rendering mechanisms of a `StackLayout` and "native" mouse handling.
3. Fixed misalignment of toolstrip items, due to some sort of black magic `PixelOffsetMode = Half` fixes the pixel murder mystery now.

I have two concerns before this is merged:
1. For WPF I had to explicitly enable tooltips on disabled items (ed25a3d). I have no idea if this is necessary on the other platforms, nor would I know how to do this.
2. The `ToolStripItemCollection` class feels a little awkward. "It was like this when I got here", but I feel like there should be a better solution.

Feel free to thoroughly go through and scorch my ~~sloppy~~ code, most was written between 1-4 AM.