### PR TITLE
I'm an idiot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,21 +1,21 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report an issue to help us improve
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-Game Name:  
-Console:  
-Format extension(s):  
-Type: [ text | image | archive | font ]  
+**Game Name:**  
+**Console:**  
+**Format extension(s):**  
+**Type:** [ text | image | archive | font ]
 
-Bug details:  
+**Bug details:**
+<!-- Please be as detailed as possible -->
 [details]
 
-Sample files (if possible):  
+**Sample files (if possible):**
+<!-- Do not attach files to the issue directly! Please use links to files hosted on other sites like Google Drive, Mega or similar. -->
 [links]
-
-DELETE ME: Do not attach files to the issue directly. Please use links to files hosted on other sites like Google Drive, Mega or similar.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,11 +1,11 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea to improve Kuriimu
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-Feature details:  
+<!-- Please describe your idea as detailed as possible! -->
 [details]

--- a/.github/ISSUE_TEMPLATE/plugin-request.md
+++ b/.github/ISSUE_TEMPLATE/plugin-request.md
@@ -1,6 +1,6 @@
 ---
 name: Plugin Request
-about: Provide details about a file from a particular game.
+about: Request a plugin for a file from a particular game.
 title: ''
 labels: ''
 assignees: ''
@@ -10,14 +10,14 @@ assignees: ''
 **Game Name:**  
 **Console:**  
 **Format extension(s):**  
-Type: [ text | image | archive | font ]  
+**Type:** [ text | image | archive | font ]
 
-**First 8 or more bytes of the file(s):**  
+**First 8 or more bytes of the file(s):**
 [extension] - [bytes in hex] - [bytes in ASCII]
 
-**More details:**  
+**More details:**
 [details]
 
-**Sample files (if possible):**  
-<!-- Do not attach files to the issue directly. Please use links to files hosted on other sites like Google Drive, Mega or similar. -->
+**Sample files (if possible):**
+<!-- Do not attach files to the issue directly! Please use links to files hosted on other sites like Google Drive, Mega or similar. -->
 [links]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,10 +213,10 @@ jobs:
     # Create github release for EtoForms
     - name: Rename releases
       run: |
-        mv ./update/Eto/Wpf/latest.zip ./update/Eto/Wpf/Kuriimu2_Windows.zip
-        mv ./update/Eto/Gtk/latest.zip ./update/Eto/Gtk/Kuriimu2_Linux.zip
-        mv ./update/Eto/Mac/latest.zip ./update/Eto/Mac/Kuriimu2_Mac.zip
-        mv ./update/Cmd/latest.zip ./update/Cmd/Kuriimu2_Cmd.zip
+        mv ./update_eto_repo/Wpf/latest.zip ./update_eto_repo/Wpf/Kuriimu2_Windows.zip
+        mv ./update_eto_repo/Gtk/latest.zip ./update_eto_repo/Gtk/Kuriimu2_Linux.zip
+        mv ./update_eto_repo/Mac/latest.zip ./update_eto_repo/Mac/Kuriimu2_Mac.zip
+        mv ./update_cmd_repo/latest.zip ./update_cmd_repo/Kuriimu2_Cmd.zip
 
     - name: Release
       uses: softprops/action-gh-release@v1
@@ -227,9 +227,9 @@ jobs:
         body_path: changelog.txt
         tag_name: ${{ steps.set_version.outputs.prop }}
         files: |
-          ./update/Eto/Wpf/Kuriimu2_Windows.zip
-          ./update/Eto/Gtk/Kuriimu2_Linux.zip
-          ./update/Eto/Mac/Kuriimu2_Mac.zip
-          ./update/Cmd/Kuriimu2_Cmd.zip
+          update_eto_repo/Wpf/Kuriimu2_Windows.zip
+          update_eto_repo/Gtk/Kuriimu2_Linux.zip
+          update_eto_repo/Mac/Kuriimu2_Mac.zip
+          update_cmd_repo/Kuriimu2_Cmd.zip
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I somehow missed that GitHub pulls issue templates from the *main* branch, rather than specifically the *master* brach. Whoops.

This PR merges `master` into `dev`, which is effectively equivalent to rebasing #86 on `dev`, with some extra mess.
Creating a "new #86" targeted to `master` might create conflicts later on though, so I think this is the most efficient solution for now.

Sorry :)