### PR TITLE
Fix GetCurrentDirectory when running in an IDE

### DIFF
--- a/src/Kore/Managers/StreamMonitor.cs
+++ b/src/Kore/Managers/StreamMonitor.cs
@@ -168,7 +168,7 @@ namespace Kore.Managers
         private string GetCurrentDirectory()
         {
             var process = Process.GetCurrentProcess().MainModule;
-            return process == null ? AppDomain.CurrentDomain.BaseDirectory : Path.GetDirectoryName(process.FileName);
+            return process == null || process.FileVersionInfo.InternalName == ".NET Host" ? AppDomain.CurrentDomain.BaseDirectory : Path.GetDirectoryName(process.FileName);
         }
 
         private void SetLogger(ILogger logger)


### PR DESCRIPTION
OTSIA.

When running inside an IDE, `GetCurrentProcess().MainModule` refers to `dotnet.exe`.
This leads to permission-denied errors when creating temporary directories during saving.