### PR TITLE
Combine RGBA channels of level5 xf font image

### DIFF
--- a/plugins/Level5/plugin_level5/3DS/Fonts/Xf.cs
+++ b/plugins/Level5/plugin_level5/3DS/Fonts/Xf.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using Komponent.Extensions;
 using Komponent.Font;
 using Komponent.IO;
 using Kontract.Models.Font;
@@ -220,7 +221,8 @@ namespace plugin_level5._3DS.Fonts
 
             // Draw textures
             var img = new Bitmap(imageSize.Width, imageSize.Height);
-            var gfx = Graphics.FromImage(img);
+            var chn = new Bitmap(imageSize.Width, imageSize.Height);
+            var gfx = Graphics.FromImage(chn);
             for (var i = 0; i < textureInfos.Count; i++)
             {
                 var destPoints = new[]
@@ -233,6 +235,7 @@ namespace plugin_level5._3DS.Fonts
                 var attr = new ImageAttributes();
                 attr.SetColorMatrix(_inverseColorMatrices[i]);
                 gfx.DrawImage(textureInfos[i].FontTexture, destPoints, rect, GraphicsUnit.Pixel, attr);
+                img.PutChannel(chn);
             }
 
             // Save fnt.bin

--- a/src/Komponent/Extensions/BitmapExtensions.cs
+++ b/src/Komponent/Extensions/BitmapExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Drawing;
+
+namespace Komponent.Extensions
+{
+    public static class BitmapExtensions
+    {
+        public static void PutChannel(this Bitmap bitmap, Bitmap channel)
+        {
+            var bmpData = bitmap.LockBits(new Rectangle(0, 0, bitmap.Width, bitmap.Height), System.Drawing.Imaging.ImageLockMode.ReadWrite, bitmap.PixelFormat);
+            var chnData = channel.LockBits(new Rectangle(0, 0, channel.Width, channel.Height), System.Drawing.Imaging.ImageLockMode.ReadOnly, channel.PixelFormat);
+
+            IntPtr ptrBmp = bmpData.Scan0;
+            IntPtr ptrChn = chnData.Scan0;
+
+            int bytesOfBmp = Math.Abs(bmpData.Stride) * bitmap.Height;
+            int bytesOfChn = Math.Abs(chnData.Stride) * channel.Height;
+            byte[] bmpPixels = new byte[bytesOfBmp];
+            byte[] chnPixels = new byte[bytesOfChn];
+
+            System.Runtime.InteropServices.Marshal.Copy(ptrBmp, bmpPixels, 0, bytesOfBmp);
+            System.Runtime.InteropServices.Marshal.Copy(ptrChn, chnPixels, 0, bytesOfChn);
+
+            for (int y = 0; y < channel.Height && y < bitmap.Height; y++)
+            {
+                for (int x = 0; x < channel.Width && x < bitmap.Width; x++)
+                {
+                    int bmpPixelIndex = ((y * bitmap.Width) + x) * 4;
+                    byte bA = bmpPixels[bmpPixelIndex + 0];
+                    byte bR = bmpPixels[bmpPixelIndex + 1];
+                    byte bG = bmpPixels[bmpPixelIndex + 2];
+                    byte bB = bmpPixels[bmpPixelIndex + 3];
+
+                    int chnPixelIndex = ((y * channel.Width) + x) * 4;
+                    byte cA = chnPixels[chnPixelIndex + 0];
+                    byte cR = chnPixels[chnPixelIndex + 1];
+                    byte cG = chnPixels[chnPixelIndex + 2];
+                    byte cB = chnPixels[chnPixelIndex + 3];
+
+                    bmpPixels[bmpPixelIndex + 0] = (byte)(bA | cA);
+                    bmpPixels[bmpPixelIndex + 1] = (byte)(bR | cR);
+                    bmpPixels[bmpPixelIndex + 2] = (byte)(bG | cG);
+                    bmpPixels[bmpPixelIndex + 3] = (byte)(bB | cB);
+                }
+            }
+
+            System.Runtime.InteropServices.Marshal.Copy(bmpPixels, 0, ptrBmp, bytesOfBmp);
+            bitmap.UnlockBits(bmpData);
+            channel.UnlockBits(chnData);
+        }
+    }
+}

--- a/src/Komponent/Extensions/BitmapExtensions.cs
+++ b/src/Komponent/Extensions/BitmapExtensions.cs
@@ -15,36 +15,36 @@ namespace Komponent.Extensions
 
             int bytesOfBmp = Math.Abs(bmpData.Stride) * bitmap.Height;
             int bytesOfChn = Math.Abs(chnData.Stride) * channel.Height;
-            byte[] bmpPixels = new byte[bytesOfBmp];
-            byte[] chnPixels = new byte[bytesOfChn];
-
-            System.Runtime.InteropServices.Marshal.Copy(ptrBmp, bmpPixels, 0, bytesOfBmp);
-            System.Runtime.InteropServices.Marshal.Copy(ptrChn, chnPixels, 0, bytesOfChn);
-
-            for (int y = 0; y < channel.Height && y < bitmap.Height; y++)
+            
+            unsafe
             {
-                for (int x = 0; x < channel.Width && x < bitmap.Width; x++)
+                Span<byte> bmpPixels = new Span<byte>(ptrBmp.ToPointer(), bytesOfBmp);
+                Span<byte> chnPixels = new Span<byte>(ptrChn.ToPointer(), bytesOfChn);
+
+                for (int y = 0; y < channel.Height && y < bitmap.Height; y++)
                 {
-                    int bmpPixelIndex = ((y * bitmap.Width) + x) * 4;
-                    byte bA = bmpPixels[bmpPixelIndex + 0];
-                    byte bR = bmpPixels[bmpPixelIndex + 1];
-                    byte bG = bmpPixels[bmpPixelIndex + 2];
-                    byte bB = bmpPixels[bmpPixelIndex + 3];
+                    for (int x = 0; x < channel.Width && x < bitmap.Width; x++)
+                    {
+                        int bmpPixelIndex = ((y * bitmap.Width) + x) * 4;
+                        byte bA = bmpPixels[bmpPixelIndex + 0];
+                        byte bR = bmpPixels[bmpPixelIndex + 1];
+                        byte bG = bmpPixels[bmpPixelIndex + 2];
+                        byte bB = bmpPixels[bmpPixelIndex + 3];
 
-                    int chnPixelIndex = ((y * channel.Width) + x) * 4;
-                    byte cA = chnPixels[chnPixelIndex + 0];
-                    byte cR = chnPixels[chnPixelIndex + 1];
-                    byte cG = chnPixels[chnPixelIndex + 2];
-                    byte cB = chnPixels[chnPixelIndex + 3];
+                        int chnPixelIndex = ((y * channel.Width) + x) * 4;
+                        byte cA = chnPixels[chnPixelIndex + 0];
+                        byte cR = chnPixels[chnPixelIndex + 1];
+                        byte cG = chnPixels[chnPixelIndex + 2];
+                        byte cB = chnPixels[chnPixelIndex + 3];
 
-                    bmpPixels[bmpPixelIndex + 0] = (byte)(bA | cA);
-                    bmpPixels[bmpPixelIndex + 1] = (byte)(bR | cR);
-                    bmpPixels[bmpPixelIndex + 2] = (byte)(bG | cG);
-                    bmpPixels[bmpPixelIndex + 3] = (byte)(bB | cB);
+                        bmpPixels[bmpPixelIndex + 0] = (byte)(bA | cA);
+                        bmpPixels[bmpPixelIndex + 1] = (byte)(bR | cR);
+                        bmpPixels[bmpPixelIndex + 2] = (byte)(bG | cG);
+                        bmpPixels[bmpPixelIndex + 3] = (byte)(bB | cB);
+                    }
                 }
             }
-
-            System.Runtime.InteropServices.Marshal.Copy(bmpPixels, 0, ptrBmp, bytesOfBmp);
+            
             bitmap.UnlockBits(bmpData);
             channel.UnlockBits(chnData);
         }


### PR DESCRIPTION
Calling Graphics.DrawImage with a ColorMatrix doesn't output a combined image. It only gives you an image of a single channel.