### PR TITLE
CTXB: Various fixes

### DIFF
--- a/plugins/Nintendo/plugin_grezzo/Images/Ctxb.cs
+++ b/plugins/Nintendo/plugin_grezzo/Images/Ctxb.cs
@@ -33,13 +33,24 @@ namespace plugin_grezzo.Images
             {
                 foreach (var texture in chunks[i].textures)
                 {
-                    //imageFormat is ignored if ETC1(a4)
-                    var format = texture.isETC1 ? texture.imageFormat : (texture.dataType << 16) | texture.imageFormat;
-
                     input.Position = header.texDataOffset + texture.dataOffset;
-                    var imageInfo = new CtxbImageInfo(br.ReadBytes(texture.dataLength), format, new Size(texture.width, texture.height), i, texture)
+
+                    // imageFormat is ignored if ETC1(a4)
+                    var format = texture.isETC1 ? texture.imageFormat : (texture.dataType << 16) | texture.imageFormat;
+                    var bitDepth = CtxbSupport.CtxbFormats[(uint)format].BitDepth;
+
+                    var dataLength = texture.width * texture.height * bitDepth / 8;
+                    var imageData = br.ReadBytes(dataLength);
+
+                    // Read mip maps
+                    var mipMaps = new byte[texture.mipLvl-1][];
+                    for (var j = 1; j < texture.mipLvl; j++)
+                        mipMaps[j-1] = br.ReadBytes((texture.width >> j) * (texture.width >> j) * bitDepth / 8);
+
+                    var imageInfo = new CtxbImageInfo(br.ReadBytes(dataLength), format, new Size(texture.width, texture.height), i, texture)
                     {
-                        Name = texture.name
+                        MipMapData = mipMaps,
+                        Name = texture.name,
                     };
 
                     imageInfo.RemapPixels.With(context => new CtrSwizzle(context));
@@ -66,24 +77,33 @@ namespace plugin_grezzo.Images
             var entries = new List<(int, CtxbEntry)>();
             foreach (var imageInfo in images.Cast<CtxbImageInfo>())
             {
+                var dataOffset = texDataPosition - texDataOffset;
+
                 output.Position = texDataOffset;
                 output.Write(imageInfo.ImageData);
 
+                // Write mipmaps
+                for (var i = 0; i < imageInfo.MipMapCount; i++)
+                {
+                    output.Write(imageInfo.MipMapData[i]);
+                    texDataPosition += imageInfo.MipMapData[i].Length;
+                }
+
+                texDataPosition += imageInfo.ImageData.Length;
+
                 entries.Add((imageInfo.ChunkIndex, new CtxbEntry
                 {
-                    dataOffset = texDataPosition - texDataOffset,
-                    dataLength = imageInfo.ImageData.Length,
+                    dataOffset = dataOffset,
+                    dataLength = texDataPosition - texDataOffset,
                     width = (short)imageInfo.ImageSize.Width,
                     height = (short)imageInfo.ImageSize.Height,
                     dataType = (ushort)(imageInfo.ImageFormat >> 16),
                     imageFormat = (ushort)imageInfo.ImageFormat,
                     mipLvl = imageInfo.Entry.mipLvl,
                     isETC1 = ((imageInfo.ImageFormat & 0xFFFF) == 0x675A || (imageInfo.ImageFormat & 0xFFFF) == 0x675B) ? true : false,
-                    isCubemap = false,
+                    isCubemap = imageInfo.Entry.isCubemap,
                     name = imageInfo.Entry.name.PadRight(0x10).Substring(0, 0x10)
                 }));
-
-                texDataPosition += imageInfo.ImageData.Length;
             }
 
             // Write chunk entries

--- a/plugins/Nintendo/plugin_grezzo/Images/Ctxb.cs
+++ b/plugins/Nintendo/plugin_grezzo/Images/Ctxb.cs
@@ -33,7 +33,8 @@ namespace plugin_grezzo.Images
             {
                 foreach (var texture in chunks[i].textures)
                 {
-                    var format = (texture.dataType << 16) | texture.imageFormat;
+                    //imageFormat is ignored if ETC1(a4)
+                    var format = texture.isETC1 ? texture.imageFormat : (texture.dataType << 16) | texture.imageFormat;
 
                     input.Position = header.texDataOffset + texture.dataOffset;
                     var imageInfo = new CtxbImageInfo(br.ReadBytes(texture.dataLength), format, new Size(texture.width, texture.height), i, texture)
@@ -76,8 +77,9 @@ namespace plugin_grezzo.Images
                     height = (short)imageInfo.ImageSize.Height,
                     dataType = (ushort)(imageInfo.ImageFormat >> 16),
                     imageFormat = (ushort)imageInfo.ImageFormat,
-                    unk1 = imageInfo.Entry.unk1,
-                    unk2 = imageInfo.Entry.unk2,
+                    mipLvl = imageInfo.Entry.mipLvl,
+                    isETC1 = ((imageInfo.ImageFormat & 0xFFFF) == 0x675A || (imageInfo.ImageFormat & 0xFFFF) == 0x675B) ? true : false,
+                    isCubemap = false,
                     name = imageInfo.Entry.name.PadRight(0x10).Substring(0, 0x10)
                 }));
 

--- a/plugins/Nintendo/plugin_grezzo/Images/Ctxb.cs
+++ b/plugins/Nintendo/plugin_grezzo/Images/Ctxb.cs
@@ -47,7 +47,7 @@ namespace plugin_grezzo.Images
                     for (var j = 1; j < texture.mipLvl; j++)
                         mipMaps[j-1] = br.ReadBytes((texture.width >> j) * (texture.width >> j) * bitDepth / 8);
 
-                    var imageInfo = new CtxbImageInfo(br.ReadBytes(dataLength), format, new Size(texture.width, texture.height), i, texture)
+                    var imageInfo = new CtxbImageInfo(imageData, format, new Size(texture.width, texture.height), i, texture)
                     {
                         MipMapData = mipMaps,
                         Name = texture.name,
@@ -78,6 +78,7 @@ namespace plugin_grezzo.Images
             foreach (var imageInfo in images.Cast<CtxbImageInfo>())
             {
                 var dataOffset = texDataPosition - texDataOffset;
+                var dataLength = imageInfo.ImageData.Length;
 
                 output.Position = texDataOffset;
                 output.Write(imageInfo.ImageData);
@@ -86,6 +87,7 @@ namespace plugin_grezzo.Images
                 for (var i = 0; i < imageInfo.MipMapCount; i++)
                 {
                     output.Write(imageInfo.MipMapData[i]);
+                    dataLength += imageInfo.MipMapData[i].Length;
                     texDataPosition += imageInfo.MipMapData[i].Length;
                 }
 
@@ -94,7 +96,7 @@ namespace plugin_grezzo.Images
                 entries.Add((imageInfo.ChunkIndex, new CtxbEntry
                 {
                     dataOffset = dataOffset,
-                    dataLength = texDataPosition - texDataOffset,
+                    dataLength = dataLength,
                     width = (short)imageInfo.ImageSize.Width,
                     height = (short)imageInfo.ImageSize.Height,
                     dataType = (ushort)(imageInfo.ImageFormat >> 16),

--- a/plugins/Nintendo/plugin_grezzo/Images/CtxbSupport.cs
+++ b/plugins/Nintendo/plugin_grezzo/Images/CtxbSupport.cs
@@ -33,8 +33,9 @@ namespace plugin_grezzo.Images
     class CtxbEntry
     {
         public int dataLength;
-        public short unk1;
-        public short unk2;
+        public short mipLvl;
+        public bool isETC1;
+        public bool isCubemap;
         public short width;
         public short height;
         public ushort imageFormat;
@@ -82,8 +83,6 @@ namespace plugin_grezzo.Images
             [0x14016758] = ImageFormats.La88(),
             [0x0000675A] = ImageFormats.Etc1(true),
             [0x0000675B] = ImageFormats.Etc1A4(true),
-            [0x1401675A] = ImageFormats.Etc1(true),
-            [0x1401675B] = ImageFormats.Etc1A4(true)
         };
 
         public static EncodingDefinition GetEncodingDefinition()

--- a/plugins/Nintendo/plugin_grezzo/Images/CtxbSupport.cs
+++ b/plugins/Nintendo/plugin_grezzo/Images/CtxbSupport.cs
@@ -66,7 +66,7 @@ namespace plugin_grezzo.Images
 
     public class CtxbSupport
     {
-        private static readonly IDictionary<uint, IColorEncoding> CtxbFormats = new Dictionary<uint, IColorEncoding>
+        public static readonly IDictionary<uint, IColorEncoding> CtxbFormats = new Dictionary<uint, IColorEncoding>
         {
             // composed of dataType and PixelFormat
             // short+short


### PR DESCRIPTION
- Fixed a crash that would happen when selecting the second ETC(a4) option when changing the texture format
- Fixed changing texture formats so textures won't sometimes appear black in-game