### PR TITLE
Fix Mac build

### DIFF
--- a/.github/workflows/etoforms_dev.yml
+++ b/.github/workflows/etoforms_dev.yml
@@ -47,20 +47,7 @@ jobs:
         echo '{"source_type": "Github Action", "version": "${{ steps.set_version.outputs.prop }}", "build_number": "${{ github.run_id }}", "application_name": "Kuriimu2" }' > ./update/Gtk/manifest.json
         echo '{"source_type": "Github Action", "version": "${{ steps.set_version.outputs.prop }}", "build_number": "${{ github.run_id }}", "application_name": "Kuriimu2.app" }' > ./update/Mac/manifest.json
         echo '{"source_type": "Github Action", "version": "${{ steps.set_version.outputs.prop }}", "build_number": ${{ github.run_id }} }' > ./src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Resources/version.json
-      
-    - name: Publish EtoForms application with dotnet
-      run: |
-        dotnet publish ./src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Wpf/Kuriimu2.EtoForms.Wpf.csproj --output ./dist/final/Wpf --configuration Release --framework netcoreapp31 --runtime win-x64 /p:PublishSingleFile=true
-        dotnet publish ./src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Gtk/Kuriimu2.EtoForms.Gtk.csproj --output ./dist/final/Gtk --configuration Release --framework netcoreapp31 --runtime linux-x64 /p:PublishSingleFile=true
-        dotnet publish ./src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Mac/Kuriimu2.EtoForms.Mac.csproj --configuration Release --framework netcoreapp31 --runtime osx-x64 /p:PublishSingleFile=true
-        mv ./dist/final/Wpf/Kuriimu2.EtoForms.Wpf.exe ./dist/final/Wpf/Kuriimu2.exe
-        mv ./dist/final/Gtk/Kuriimu2.EtoForms.Gtk ./dist/final/Gtk/Kuriimu2
-        mkdir ./dist/final/Mac
-        mv ./dist/Release/netcoreapp31/Kuriimu2.EtoForms.Mac.app ./dist/final/Mac/Kuriimu2.app
-        mv ./dist/final/Mac/Kuriimu2.app/Contents/MacOS/Kuriimu2.EtoForms.Mac ./dist/final/Mac/Kuriimu2.app/Contents/MacOS/Kuriimu2
-        rm ./dist/final/Wpf/*.pdb
-        rm ./dist/final/Gtk/*.pdb
-      
+
     - name: Pack libraries
       run: |
         dotnet build ./src/Kontract/Kontract.csproj --configuration Release
@@ -111,11 +98,22 @@ jobs:
         rm ./dist/final/plugins/*.pdb
         rm ./dist/final/plugins/*.deps.json
         
+    - name: Publish EtoForms application with dotnet
+      run: |
+        dotnet publish ./src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Wpf/Kuriimu2.EtoForms.Wpf.csproj --output ./dist/final/Wpf --configuration Release --framework netcoreapp31 --runtime win-x64 /p:PublishSingleFile=true
+        dotnet publish ./src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Gtk/Kuriimu2.EtoForms.Gtk.csproj --output ./dist/final/Gtk --configuration Release --framework netcoreapp31 --runtime linux-x64 /p:PublishSingleFile=true
+        dotnet publish ./src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Mac/Kuriimu2.EtoForms.Mac.csproj --configuration Release --framework netcoreapp31 --runtime osx-x64 /p:PublishSingleFile=true
+        mv ./dist/final/Wpf/Kuriimu2.EtoForms.Wpf.exe ./dist/final/Wpf/Kuriimu2.exe
+        mv ./dist/final/Gtk/Kuriimu2.EtoForms.Gtk ./dist/final/Gtk/Kuriimu2
+        mkdir ./dist/final/Mac
+        mv ./dist/Release/netcoreapp31/Kuriimu2.app ./dist/final/Mac/Kuriimu2.app
+        rm ./dist/final/Wpf/*.pdb
+        rm ./dist/final/Gtk/*.pdb
+        
     - name: Copy plugins to applications
       run: |
         xcopy /I .\dist\final\plugins .\dist\final\Wpf\plugins
         xcopy /I .\dist\final\plugins .\dist\final\Gtk\plugins
-        xcopy /I .\dist\final\plugins .\dist\final\Mac\plugins
       shell: cmd
       
     - name: Zip Wpf release

--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Mac/Kuriimu2.EtoForms.Mac.csproj
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms.Mac/Kuriimu2.EtoForms.Mac.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>netcoreapp31</TargetFrameworks>
+    <AssemblyName>Kuriimu2</AssemblyName>
+    <MacBundleName>Kuriimu2</MacBundleName>
     
     <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
 
@@ -15,7 +17,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.6.0-ci-20210612.931419801" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.6.0-ci-20211019.1357802759" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -25,5 +27,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\..\dist\Release\</OutputPath>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <!-- compile plugins first.. -->
+    <None Include="..\..\..\dist\final\plugins\*.dll" Link="plugins\%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 
 </Project>

--- a/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/MainForm.cs
+++ b/src/Kuriimu2.EtoForms/Kuriimu2.EtoForms/Forms/MainForm.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using Eto;
 using Eto.Drawing;
 using Eto.Forms;
 using Kontract.Extensions;
@@ -138,7 +139,7 @@ namespace Kuriimu2.EtoForms.Forms
             _logFile = $"{GetBaseDirectory()}/Kuriimu2.log";
             _logger = new LoggerConfiguration().WriteTo.File(_logFile).CreateLogger();
             _progress = new ProgressContext(new ProgressBarExOutput(_progressBarEx, 20));
-            _fileManager = new FileManager($"{GetBaseDirectory()}/plugins")
+            _fileManager = new FileManager(Path.Combine(GetBaseDirectory(), "plugins"))
             {
                 AllowManualSelection = true,
 
@@ -894,7 +895,7 @@ namespace Kuriimu2.EtoForms.Forms
                 return ".";
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return "~/Applications/Kuriimu2";
+                return EtoEnvironment.GetFolderPath(EtoSpecialFolder.EntryExecutable);
 
             throw new InvalidOperationException(Localize(UnsupportedOperatingSystemExceptionKey_, RuntimeInformation.OSDescription));
         }


### PR DESCRIPTION
- Copy plugins during build vs after
- Use EtoEnvironment.GetFolderPath to get the proper directory to use
- Name both the assembly and bundle correctly so it runs

This implements what I was mentioning in https://github.com/picoe/Eto/issues/1999.  Basically you need to copy the plugins as part of the build of the Mac app, vs after.  This should allow it to pass code signing.

I ran the application and it still doesn't appear to function quite correctly, but it does at least load the plugins 🤷🏻‍♂️