### PR TITLE
Update action dependency to properly run automatic builds

### DIFF
--- a/.github/workflows/cmd_dev.yml
+++ b/.github/workflows/cmd_dev.yml
@@ -116,19 +116,19 @@ jobs:
       shell: cmd
       
     - name: Zip Windows release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Windows
         dest: ./update/Windows/latest.zip
       
     - name: Zip Linux release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Linux
         dest: ./update/Linux/latest.zip
         
     - name: Zip Mac release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Mac
         dest: ./update/Mac/latest.zip

--- a/.github/workflows/etoforms_dev.yml
+++ b/.github/workflows/etoforms_dev.yml
@@ -117,19 +117,19 @@ jobs:
       shell: cmd
       
     - name: Zip Wpf release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Wpf
         dest: ./update/Wpf/latest.zip
       
     - name: Zip Gtk release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Gtk
         dest: ./update/Gtk/latest.zip
         
     - name: Zip Mac release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Mac
         dest: ./update/Mac/latest.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,37 +159,37 @@ jobs:
 
     # Prepare release archives
     - name: Zip EtoForms Windows release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Eto/Wpf
         dest: ./update/Eto/Wpf/latest.zip
 
     - name: Zip EtoForms Linux release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Eto/Gtk
         dest: ./update/Eto/Gtk/latest.zip
 
     - name: Zip EtoForms Mac release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Eto/Mac
         dest: ./update/Eto/Mac/latest.zip
 
     - name: Zip Cmd Windows release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Cmd/Windows
         dest: ./update/Cmd/Windows/latest.zip
 
     - name: Zip Cmd Linux release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Cmd/Linux
         dest: ./update/Cmd/Linux/latest.zip
 
     - name: Zip Cmd Mac release
-      uses: papeloto/action-zip@v1
+      uses: vimtor/action-zip@v1
       with:
         files: ./dist/final/Cmd/Mac
         dest: ./update/Cmd/Mac/latest.zip


### PR DESCRIPTION
Correct source repo of zipping action used in Kuriimu2's GH Actions workflows to (hopefully) let them run properly again.