### PR TITLE
Update BLN plugin archive naming with archive IDs

### DIFF
--- a/plugins/Shade/plugin_shade/Archives/Bln.cs
+++ b/plugins/Shade/plugin_shade/Archives/Bln.cs
@@ -31,7 +31,7 @@ namespace plugin_shade.Archives
             foreach (var indexEntry in indexEntries)
             {
                 var stream = new SubStream(dataStream, indexEntry.offset, indexEntry.size);
-                result.Add(new BlnArchiveFileInfo(stream, $"{indexEntry.id:X4}_{index++:D8}.bin", indexEntry)
+                result.Add(new BlnArchiveFileInfo(stream, $"{index++:D8}_{indexEntry.id:X4}.bin", indexEntry)
                 {
                     PluginIds = new[] { Guid.Parse("6d71d07c-b517-496b-b659-3498cd3542fd") }
                 });

--- a/plugins/Shade/plugin_shade/Archives/Bln.cs
+++ b/plugins/Shade/plugin_shade/Archives/Bln.cs
@@ -26,11 +26,12 @@ namespace plugin_shade.Archives
             _unkIndexData = indexBr.ReadBytes((int)(indexBr.BaseStream.Length - indexBr.BaseStream.Position));
 
             // Parse files from mcb1
+            int index = 0;
             var result = new List<IArchiveFileInfo>();
             foreach (var indexEntry in indexEntries)
             {
                 var stream = new SubStream(dataStream, indexEntry.offset, indexEntry.size);
-                result.Add(new BlnArchiveFileInfo(stream, $"{indexEntry.id:X4}.bin", indexEntry)
+                result.Add(new BlnArchiveFileInfo(stream, $"{indexEntry.id:X4}_{index++:D8}.bin", indexEntry)
                 {
                     PluginIds = new[] { Guid.Parse("6d71d07c-b517-496b-b659-3498cd3542fd") }
                 });

--- a/plugins/Shade/plugin_shade/Archives/Bln.cs
+++ b/plugins/Shade/plugin_shade/Archives/Bln.cs
@@ -26,12 +26,11 @@ namespace plugin_shade.Archives
             _unkIndexData = indexBr.ReadBytes((int)(indexBr.BaseStream.Length - indexBr.BaseStream.Position));
 
             // Parse files from mcb1
-            var index = 0;
             var result = new List<IArchiveFileInfo>();
             foreach (var indexEntry in indexEntries)
             {
                 var stream = new SubStream(dataStream, indexEntry.offset, indexEntry.size);
-                result.Add(new BlnArchiveFileInfo(stream, $"{index++:00000000}.bin", indexEntry)
+                result.Add(new BlnArchiveFileInfo(stream, $"{indexEntry.id:X4}.bin", indexEntry)
                 {
                     PluginIds = new[] { Guid.Parse("6d71d07c-b517-496b-b659-3498cd3542fd") }
                 });

--- a/plugins/Shade/plugin_shade/Archives/BlnSubSupport.cs
+++ b/plugins/Shade/plugin_shade/Archives/BlnSubSupport.cs
@@ -15,6 +15,7 @@ namespace plugin_shade.Archives
 	// 0x00 => grp.bin
 	// 0x01 => dat.bin
 	// 0x02 => scr.bin
+    // 0x03 => evt.bin
 	
     class BlnSubEntry
     {

--- a/plugins/Shade/plugin_shade/Archives/BlnSupport.cs
+++ b/plugins/Shade/plugin_shade/Archives/BlnSupport.cs
@@ -7,7 +7,7 @@ namespace plugin_shade.Archives
 {
     class Mcb0Entry
     {
-        public short unk1;
+        public short id;
         public short unk2;
         public uint offset;
         public uint size;


### PR DESCRIPTION
Based on original research into Suzumiya Haruhi no Heiretsu, the MCB archives contained in BLNs actually have IDs that should be used as their "names" as that ID is how the engine decides which archive to load. See the debug logging below:

![image](https://user-images.githubusercontent.com/69772986/162549349-564e98bd-18dd-4904-abcf-187838d82542.png)

This value matches the value of `unk1`, which I have renamed to `id`. Additionally, I have replaced the archive name with this ID displayed in hexadecimal.

cc/ @obluda3 @onepiecefreak3 