### PR TITLE
Implement 3DST (Nintendo Anime Channel) support

### DIFF
--- a/plugins/Nintendo/plugin_nintendo/Images/3dst.cs
+++ b/plugins/Nintendo/plugin_nintendo/Images/3dst.cs
@@ -1,0 +1,53 @@
+﻿using System.Drawing;
+using System.IO;
+using Kanvas.Swizzle;
+using Komponent.IO;
+using Kontract.Models.Image;
+
+namespace plugin_nintendo.Images
+{
+    class _3dst
+    {
+        private static readonly int HeaderSize = Tools.MeasureType(typeof(_3dstHeader));
+
+        private _3dstHeader _header;
+
+        public ImageInfo Load(Stream input)
+        {
+            using var br = new BinaryReaderX(input);
+
+            // Read header
+            _header = br.ReadType<_3dstHeader>();
+
+            // Read image data
+            var imgData = br.ReadBytes((int)(input.Length - 0x80));
+
+            // Create image info
+            var imageInfo = new ImageInfo(imgData, _header.format, new Size(_header.width, _header.height));
+            imageInfo.RemapPixels.With(context => new CtrSwizzle(context));
+
+            return imageInfo;
+        }
+
+        public void Save(Stream output, ImageInfo imageInfo)
+        {
+            using var bw = new BinaryWriterX(output);
+
+            // Calculate offsets
+            var dataOffset = 0x80;
+
+            // Write image data
+            output.Position = dataOffset;
+            bw.Write(imageInfo.ImageData);
+
+            // Update header
+            _header.format = (short)imageInfo.ImageFormat;
+            _header.width = (short)imageInfo.ImageSize.Width;
+            _header.height = (short)imageInfo.ImageSize.Height;
+
+            // Write header
+            output.Position = 0;
+            bw.WriteType(_header);
+        }
+    }
+}

--- a/plugins/Nintendo/plugin_nintendo/Images/3dst.cs
+++ b/plugins/Nintendo/plugin_nintendo/Images/3dst.cs
@@ -20,6 +20,7 @@ namespace plugin_nintendo.Images
             _header = br.ReadType<_3dstHeader>();
 
             // Read image data
+            br.BaseStream.Position = 0x80;
             var imgData = br.ReadBytes((int)(input.Length - 0x80));
 
             // Create image info

--- a/plugins/Nintendo/plugin_nintendo/Images/3dstPlugin.cs
+++ b/plugins/Nintendo/plugin_nintendo/Images/3dstPlugin.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+using Komponent.IO;
+using Kontract.Interfaces.FileSystem;
+using Kontract.Interfaces.Managers;
+using Kontract.Interfaces.Plugins.Identifier;
+using Kontract.Interfaces.Plugins.State;
+using Kontract.Models;
+using Kontract.Models.Context;
+using Kontract.Models.IO;
+
+namespace plugin_nintendo.Images
+{
+    public class _3dstPlugin : IFilePlugin, IIdentifyFiles
+    {
+        public Guid PluginId => Guid.Parse("1fa3a56c-864c-4618-9dfc-22734b91d4c5");
+        public PluginType PluginType => PluginType.Image;
+        public string[] FileExtensions => new[] { "*.3dst" };
+        public PluginMetadata Metadata { get; }
+
+        public _3dstPlugin()
+        {
+            Metadata = new PluginMetadata("3DST", "DaniElectra", "The image format used for textures and thumbnails on Nintendo Anime Channel.");
+        }
+
+        public async Task<bool> IdentifyAsync(IFileSystem fileSystem, UPath filePath, IdentifyContext identifyContext)
+        {
+            var fileStream = await fileSystem.OpenFileAsync(filePath);
+
+            using var br = new BinaryReaderX(fileStream);
+            var magic = br.ReadString(7);
+            return magic == "texture";
+        }
+
+        public IPluginState CreatePluginState(IBaseFileManager fileManager)
+        {
+            return new _3dstState();
+        }
+    }
+}

--- a/plugins/Nintendo/plugin_nintendo/Images/3dstState.cs
+++ b/plugins/Nintendo/plugin_nintendo/Images/3dstState.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Kanvas;
+using Kontract.Interfaces.FileSystem;
+using Kontract.Interfaces.Plugins.State;
+using Kontract.Kanvas;
+using Kontract.Models.Context;
+using Kontract.Models.Image;
+using Kontract.Models.IO;
+
+namespace plugin_nintendo.Images
+{
+    class _3dstState : IImageState, ILoadFiles, ISaveFiles
+    {
+        private _3dst _3dst;
+
+        public EncodingDefinition EncodingDefinition { get; }
+        public IList<IKanvasImage> Images { get; private set; }
+
+        public bool ContentChanged => IsContentChanged();
+
+        public _3dstState()
+        {
+            _3dst = new _3dst();
+
+            EncodingDefinition = _3dstSupport.GetEncodingDefinition();
+        }
+
+        public async Task Load(IFileSystem fileSystem, UPath filePath, LoadContext loadContext)
+        {
+            var fileStream = await fileSystem.OpenFileAsync(filePath);
+            Images = new List<IKanvasImage> { new KanvasImage(EncodingDefinition, _3dst.Load(fileStream)) };
+        }
+
+        public Task Save(IFileSystem fileSystem, UPath savePath, SaveContext saveContext)
+        {
+            var fileStream = fileSystem.OpenFile(savePath, FileMode.Create, FileAccess.Write);
+            _3dst.Save(fileStream, Images[0].ImageInfo);
+
+            return Task.CompletedTask;
+        }
+
+        private bool IsContentChanged()
+        {
+            return Images.Any(x => x.ContentChanged);
+        }
+    }
+}

--- a/plugins/Nintendo/plugin_nintendo/Images/3dstSupport.cs
+++ b/plugins/Nintendo/plugin_nintendo/Images/3dstSupport.cs
@@ -24,18 +24,11 @@ namespace plugin_nintendo.Images
         {
             [0] = ImageFormats.Rgba8888(),
             [1] = ImageFormats.Rgb888(),
-            // [2] = ImageFormats.La88(),
-            // [3] = ImageFormats.Rg88(),
+            [2] = ImageFormats.A8(),
             [4] = ImageFormats.Etc1(true),
             [5] = ImageFormats.Rgba5551(),
             [6] = ImageFormats.Rgb565(),
-            [7] = ImageFormats.Rgba4444(),
-            // [8] = ImageFormats.A8(),
-            // [9] = ImageFormats.La44(),
-            // [10] = ImageFormats.L4(),
-            // [11] = ImageFormats.A4(),
-            // [12] = ImageFormats.L8(),
-            // [13] = ImageFormats.Etc1A4(true),
+            [7] = ImageFormats.Rgba4444()
         };
 
         public static EncodingDefinition GetEncodingDefinition()

--- a/plugins/Nintendo/plugin_nintendo/Images/3dstSupport.cs
+++ b/plugins/Nintendo/plugin_nintendo/Images/3dstSupport.cs
@@ -22,11 +22,11 @@ namespace plugin_nintendo.Images
     {
         private static readonly IDictionary<int, IColorEncoding> Formats = new Dictionary<int, IColorEncoding>
         {
-            // [0] = ImageFormats.Rgba8888(),
-            // [1] = ImageFormats.Rgb888(),
+            [0] = ImageFormats.Rgba8888(),
+            [1] = ImageFormats.Rgb888(),
             // [2] = ImageFormats.Rgba5551(),
             // [3] = ImageFormats.Rgb565(),
-            // [4] = ImageFormats.Rgba4444(),
+            [4] = ImageFormats.Etc1(true),
             // [5] = ImageFormats.La88(),
             // [6] = ImageFormats.Rg88(),
             // [7] = ImageFormats.L8(),
@@ -34,10 +34,8 @@ namespace plugin_nintendo.Images
             // [9] = ImageFormats.La44(),
             // [10] = ImageFormats.L4(),
             // [11] = ImageFormats.A4(),
-            // [12] = ImageFormats.Etc1(true),
+            // [12] = ImageFormats.Rgba4444(),
             // [13] = ImageFormats.Etc1A4(true),
-            [0] = ImageFormats.Rgba8888(),
-            [4] = ImageFormats.Etc1(true),
         };
 
         public static EncodingDefinition GetEncodingDefinition()

--- a/plugins/Nintendo/plugin_nintendo/Images/3dstSupport.cs
+++ b/plugins/Nintendo/plugin_nintendo/Images/3dstSupport.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Kanvas;
+using Komponent.IO.Attributes;
+using Kontract.Kanvas;
+using Kontract.Models.Image;
+
+namespace plugin_nintendo.Images
+{
+    class _3dstHeader
+    {
+        [FixedLength(7)]
+        public string magic;
+        public int zero1;
+        public int zero2;
+        public byte zero3;
+        public short width;
+        public short height;
+        public short format;
+    }
+
+    class _3dstSupport
+    {
+        private static readonly IDictionary<int, IColorEncoding> Formats = new Dictionary<int, IColorEncoding>
+        {
+            // [0] = ImageFormats.Rgba8888(),
+            // [1] = ImageFormats.Rgb888(),
+            // [2] = ImageFormats.Rgba5551(),
+            // [3] = ImageFormats.Rgb565(),
+            // [4] = ImageFormats.Rgba4444(),
+            // [5] = ImageFormats.La88(),
+            // [6] = ImageFormats.Rg88(),
+            // [7] = ImageFormats.L8(),
+            // [8] = ImageFormats.A8(),
+            // [9] = ImageFormats.La44(),
+            // [10] = ImageFormats.L4(),
+            // [11] = ImageFormats.A4(),
+            // [12] = ImageFormats.Etc1(true),
+            // [13] = ImageFormats.Etc1A4(true),
+            [0] = ImageFormats.Rgba8888(),
+            [4] = ImageFormats.Etc1(true),
+        };
+
+        public static EncodingDefinition GetEncodingDefinition()
+        {
+            var definition = new EncodingDefinition();
+            definition.AddColorEncodings(Formats);
+
+            return definition;
+        }
+    }
+}

--- a/plugins/Nintendo/plugin_nintendo/Images/3dstSupport.cs
+++ b/plugins/Nintendo/plugin_nintendo/Images/3dstSupport.cs
@@ -24,17 +24,17 @@ namespace plugin_nintendo.Images
         {
             [0] = ImageFormats.Rgba8888(),
             [1] = ImageFormats.Rgb888(),
-            // [2] = ImageFormats.Rgba5551(),
-            // [3] = ImageFormats.Rgb565(),
+            // [2] = ImageFormats.La88(),
+            // [3] = ImageFormats.Rg88(),
             [4] = ImageFormats.Etc1(true),
-            // [5] = ImageFormats.La88(),
-            // [6] = ImageFormats.Rg88(),
-            // [7] = ImageFormats.L8(),
+            [5] = ImageFormats.Rgba5551(),
+            [6] = ImageFormats.Rgb565(),
+            [7] = ImageFormats.Rgba4444(),
             // [8] = ImageFormats.A8(),
             // [9] = ImageFormats.La44(),
             // [10] = ImageFormats.L4(),
             // [11] = ImageFormats.A4(),
-            // [12] = ImageFormats.Rgba4444(),
+            // [12] = ImageFormats.L8(),
             // [13] = ImageFormats.Etc1A4(true),
         };
 


### PR DESCRIPTION
Add support for 3DST images, used on Nintendo Anime Channel for textures and thumbnails.

**Notes:**
- This PR isn't compatible with 3DST images from Minecraft for New 3DS, as they use a different implementation.
- AFAIK, the Nintendo Anime Channel application only supports resolutions which belong to a power of 2 (based on my testing).
- The number 3 is missing from the dictionary. That's because the Nintendo Anime Channel doesn't have a format assigned to that number (if you try to load an image with that format number, it won't display anything).