### PR TITLE
BG4 plugin fix & BackwardLz77 logic revert

### DIFF
--- a/plugins/Nintendo/plugin_alpha_dream/Archives/Bg4.cs
+++ b/plugins/Nintendo/plugin_alpha_dream/Archives/Bg4.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Komponent.IO;
 using Komponent.IO.Streams;
 using Kompression.Implementations;
+using Kontract.Extensions;
 using Kontract.Models.Archive;
 using Kryptography.Hash;
 

--- a/plugins/Nintendo/plugin_alpha_dream/Archives/Bg4.cs
+++ b/plugins/Nintendo/plugin_alpha_dream/Archives/Bg4.cs
@@ -56,7 +56,7 @@ namespace plugin_alpha_dream.Archives
             var stringPosition = 0;
             var stringDictionary = new Dictionary<string, int>();
 
-            foreach (var distinctString in files.Select(x => x.FilePath.FullName).Distinct())
+            foreach (var distinctString in files.Select(x => x.FilePath.ToRelative().FullName).Distinct())
             {
                 stringDictionary[distinctString] = stringPosition;
                 stringPosition += Encoding.ASCII.GetByteCount(distinctString) + 1;
@@ -76,7 +76,7 @@ namespace plugin_alpha_dream.Archives
                 var writtenSize = file.SaveFileData(output);
 
                 // Create entry
-                var fileName = file.FilePath.FullName;
+                var fileName = file.FilePath.ToRelative().FullName;
                 entries.Add(new Bg4Entry
                 {
                     FileOffset = filePosition,

--- a/src/Kompression/Implementations/Decoders/Nintendo/BackwardLz77Decoder.cs
+++ b/src/Kompression/Implementations/Decoders/Nintendo/BackwardLz77Decoder.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.IO;
 using Komponent.IO.Streams;
 using Kompression.Extensions;
@@ -19,49 +20,149 @@ namespace Kompression.Implementations.Decoders.Nintendo
 
         public void Decode(Stream input, Stream output)
         {
-            var buffer = new byte[4];
-            input.Position = input.Length - 8;
-
-            input.Read(buffer, 0, 4);
-            var bufferTopAndBottom = _byteOrder == ByteOrder.LittleEndian ? buffer.GetInt32LittleEndian(0) : buffer.GetInt32BigEndian(0);
-
-            input.Read(buffer, 0, 4);
-            var decompressedOffset = _byteOrder == ByteOrder.LittleEndian ? buffer.GetInt32LittleEndian(0) : buffer.GetInt32BigEndian(0);
-
-            var footerLength = bufferTopAndBottom >> 24;
-            var compressedSize = bufferTopAndBottom & 0xFFFFFF;
-
-            using (var inputReverseStream = new ReverseStream(input, input.Length - footerLength))
-            using (var outputReverseStream = new ReverseStream(output, input.Length + decompressedOffset))
+            // Check if enough space exists for a footer
+            if (input.Length >= 8)
             {
-                var endPosition = compressedSize - footerLength;
-                ReadCompressedData(inputReverseStream, outputReverseStream, endPosition);
+                // Read footer
+                var buffer = new byte[4];
+                input.Position = input.Length - 8;
+
+                input.Read(buffer, 0, 4);
+                var bufferTopAndBottom = _byteOrder == ByteOrder.LittleEndian
+                    ? buffer.GetInt32LittleEndian(0)
+                    : buffer.GetInt32BigEndian(0);
+
+                input.Read(buffer, 0, 4);
+                var decompressedOffset = _byteOrder == ByteOrder.LittleEndian
+                    ? buffer.GetInt32LittleEndian(0)
+                    : buffer.GetInt32BigEndian(0);
+                var decompressedSize = input.Length + decompressedOffset;
+
+                var top = bufferTopAndBottom & 0xFFFFFF;
+                var bottom = bufferTopAndBottom >> 24 & 0xFF;
+
+                // Check footer integrity
+                if (bottom >= 8 && bottom <= 8 + 3 && top >= bottom && top <= input.Length &&
+                    decompressedSize >= input.Length + decompressedOffset)
+                    ReadCompressedData(input, output, decompressedSize, decompressedSize, input.Length - bottom,
+                        input.Length - top);
+                else
+                {
+                    Debugger.Break();
+                    throw new InvalidOperationException("Something went wrong.");
+                }
             }
+            else
+            {
+                Debugger.Break();
+                throw new InvalidOperationException("Something went wrong.");
+            }
+
+            //using (var inputReverseStream = new ReverseStream(input, input.Length - footerLength))
+            //using (var outputReverseStream = new ReverseStream(output, input.Length + decompressedOffset))
+            //{
+            //ReadCompressedData(input, output, decompressedSize, decompressedSize, input.Length - bottom, input.Length - top);
+            //}
         }
 
-        private void ReadCompressedData(Stream input, Stream output, long endPosition)
+        private void ReadCompressedData(Stream input, Stream output, long decompressedSize, long dest, long src, long end)
         {
-            var circularBuffer = new CircularBuffer(0x1002);
-
-            var codeBlock = input.ReadByte();
-            var codeBlockPosition = 8;
-            while (input.Position < endPosition)
+            while (src - end > 0)
             {
-                if (codeBlockPosition == 0)
-                {
-                    codeBlock = input.ReadByte();
-                    codeBlockPosition = 8;
-                }
+                input.Position = --src;
+                var flag = input.ReadByte();
 
-                var flag = (codeBlock >> --codeBlockPosition) & 0x1;
-                if (flag == 0)
-                    HandleUncompressedBlock(input, output, circularBuffer);
-                else
-                    HandleCompressedBlock(input, output, circularBuffer);
+                for (var i = 0; i < 8; i++)
+                {
+                    if (((flag << i) & 0x80) == 0)
+                    {
+                        if (dest - end < 1 || src - end < 1)
+                        {
+                            Debugger.Break();
+                            throw new InvalidOperationException("Something went wrong.");
+                        }
+
+                        input.Position = --src;
+                        var value = input.ReadByte();
+
+                        output.Position = --dest;
+                        output.WriteByte((byte)value);
+                    }
+                    else
+                    {
+                        if (src - end < 2)
+                        {
+                            Debugger.Break();
+                            throw new InvalidOperationException("Something went wrong.");
+                        }
+
+                        input.Position = --src;
+                        var size = input.ReadByte();
+
+                        input.Position = --src;
+                        var offset = (((size & 0x0F) << 8) | input.ReadByte()) + 3;
+                        size = ((size >> 4) & 0x0F) + 3;
+
+                        if(dest<0x60)
+                            Debugger.Break();
+
+                        if (size > dest - end)
+                        {
+                            Debugger.Break();
+                            throw new InvalidOperationException("Something went wrong.");
+                        }
+
+                        var data = dest + offset;
+                        if (data > decompressedSize)
+                        {
+                            Debugger.Break();
+                            throw new InvalidOperationException("Something went wrong.");
+                        }
+
+                        for (var j = 0; j < size; j++)
+                        {
+                            output.Position = --data;
+                            var value = output.ReadByte();
+
+                            output.Position = --dest;
+                            output.WriteByte((byte)value);
+                        }
+                    }
+
+                    if (src - end <= 0)
+                        break;
+                }
             }
 
-            while (input.Position < input.Length)
-                output.WriteByte((byte)input.ReadByte());
+            // Copy remaining bytes after end
+            input.Position = 0;
+            output.Position = 0;
+
+            var buffer = new byte[end];
+            input.Read(buffer);
+            output.Write(buffer);
+
+            //var circularBuffer = new CircularBuffer(0x1002);
+
+            //var codeBlock = input.ReadByte();
+            //var codeBlockPosition = 8;
+            //while (input.Position < endPosition)
+            //{
+            //    if (codeBlockPosition == 0)
+            //    {
+            //        codeBlock = input.ReadByte();
+            //        codeBlockPosition = 8;
+            //    }
+
+            //    var flag = (codeBlock >> --codeBlockPosition) & 0x1;
+            //    if (flag == 0)
+            //        HandleUncompressedBlock(input, output, circularBuffer);
+            //    else
+            //        HandleCompressedBlock(input, output, circularBuffer);
+            //}
+
+            //while (input.Position < input.Length)
+            //    output.WriteByte((byte)input.ReadByte());
         }
 
         private void HandleUncompressedBlock(Stream input, Stream output, CircularBuffer circularBuffer)


### PR DESCRIPTION
The BG4 plugin's saving feature was completely non-functional from my testing with Superstar Saga DX / Bowser's Inside Story DX as I reported in #295

Two changes:

- I made the paths used when saving relative which fixed name and hash discrepancies.
- I'm not entirely familiar as to why the BackwardLz77 encoding/decoding was changed previously, but reverting those changes seems to fix issues with the BG4 plugin. This algorithm is also used by the HpiHpb plugin, so I have a feeling that the revert may also fix issues with that plugin if they occurred. The alternative is that this change would break that plugin which may be concerning. Since the plugin was last update before the original BackwardLz77 rewrite, I am inclined to believe that it should work with my revert.


**I highly recommend that someone who has access to HpiHpb files use the plugin with the reverted algorithm to make sure it is functional with the changes!!**


If preferred, I can split this into two PRs, but I figured its alright for this to be one PR.