### PR TITLE
Update APK archive to support akb48 games (tested on ps3 akb 1/149)

### DIFF
--- a/plugins/BandaiNamco/plugin_bandai_namco/Archives/ApkPlugin.cs
+++ b/plugins/BandaiNamco/plugin_bandai_namco/Archives/ApkPlugin.cs
@@ -22,8 +22,8 @@ namespace plugin_bandai_namco.Archives
             Name = "APK",
             Publisher = "Bandai Namco",
             Developer = "Bandai Namco",
-            Platform = ["3DS"],
-            LongDescription = "Main package resource in Gundam 3D Battle."
+            Platform = ["3DS,PSP,PSVita,PS3"],
+            LongDescription = "Main package resource in Gundam 3D Battle and AKB48 dating sim Games."
         };
 
         public async Task<bool> IdentifyAsync(IFileSystem fileSystem, UPath filePath, IdentifyContext identifyContext)

--- a/plugins/BandaiNamco/plugin_bandai_namco/Archives/ApkSupport.cs
+++ b/plugins/BandaiNamco/plugin_bandai_namco/Archives/ApkSupport.cs
@@ -47,11 +47,11 @@ namespace plugin_bandai_namco.Archives
         public int stringIndex;
         public int headerIndex;
         public int zero0;
-        public int offset;
+        public uint offset;
         public int count;
-        public int decompSize;
+        public uint decompSize;
         public int zero1;
-        public int compSize;
+        public uint compSize;
         public int zero2;
     }
 
@@ -165,11 +165,11 @@ namespace plugin_bandai_namco.Archives
                 stringIndex = reader.ReadInt32(),
                 headerIndex = reader.ReadInt32(),
                 zero0 = reader.ReadInt32(),
-                offset = reader.ReadInt32(),
+                offset = reader.ReadUInt32(),
                 count = reader.ReadInt32(),
-                decompSize = reader.ReadInt32(),
+                decompSize = reader.ReadUInt32(),
                 zero1 = reader.ReadInt32(),
-                compSize = reader.ReadInt32(),
+                compSize = reader.ReadUInt32(),
                 zero2 = reader.ReadInt32()
             };
         }
@@ -193,11 +193,10 @@ namespace plugin_bandai_namco.Archives
             var name = strings[entry.stringIndex];
 
             var isDirectory = (entry.flags & 0x1) > 0;
-            var isCompressed = (entry.flags & 0x200) > 0;
 
             if (isDirectory)
             {
-                foreach (var subEntry in entries.Skip(entry.offset).Take(entry.count))
+                foreach (var subEntry in entries.Skip((int)entry.offset).Take(entry.count))
                     foreach (var file in EnumerateFiles(streams, subEntry, path / name, apkHeaders, strings, entries))
                         yield return file;
             }
@@ -208,20 +207,34 @@ namespace plugin_bandai_namco.Archives
                     yield break;
 
                 ArchiveFileInfo fileInfo;
-                if (isCompressed)
+                if ((entry.flags & 0x200) > 0)
+                {
                     fileInfo = new CompressedArchiveFileInfo
                     {
                         FilePath = (headerName / path.ToRelative() / name).FullName,
                         FileData = new SubStream(stream, entry.offset, entry.compSize),
                         Compression = Compressions.ZLib.Build(),
-                        DecompressedSize = entry.decompSize
+                        DecompressedSize = (int)entry.decompSize
                     };
+                }
+                else if ((entry.flags & 0x300) > 0)
+                {
+                    fileInfo = new CompressedArchiveFileInfo
+                    {
+                        FilePath = (headerName / path.ToRelative() / name).FullName,
+                        FileData = new SubStream(stream, entry.offset, entry.compSize),
+                        Compression = Compressions.LZMA.Build(),
+                        DecompressedSize = (int)entry.decompSize
+                    };
+                }
                 else
+                {
                     fileInfo = new ArchiveFileInfo
                     {
                         FilePath = (headerName / path.ToRelative() / name).FullName,
                         FileData = new SubStream(stream, entry.offset, entry.decompSize)
                     };
+                }
 
                 yield return new ApkArchiveFile(fileInfo, entry.headerIndex);
             }
@@ -373,7 +386,7 @@ namespace plugin_bandai_namco.Archives
                     {
                         flags = 1,
                         stringIndex = strings.IndexOf(currentEntry.Name),
-                        offset = nextIndex,
+                        offset = (uint)nextIndex,
                         count = currentEntry.Directories.Count + currentEntry.Files.Count
                     };
 
@@ -408,9 +421,9 @@ namespace plugin_bandai_namco.Archives
                         flags = file.UsesCompression ? 0x200 : 0,
                         headerIndex = file.HeaderIndex,
                         stringIndex = strings.IndexOf(dirFile.Item1),
-                        offset = (int)dataOffset,
-                        compSize = file.UsesCompression ? (int)writtenSize : 0,
-                        decompSize = (int)file.FileSize
+                        offset = (uint)dataOffset,
+                        compSize = file.UsesCompression ? (uint)writtenSize : 0,
+                        decompSize = (uint)file.FileSize
                     };
 
                     output.Position = position;

--- a/plugins/BandaiNamco/plugin_bandai_namco/plugin_bandai_namco.csproj
+++ b/plugins/BandaiNamco/plugin_bandai_namco/plugin_bandai_namco.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Kanvas" Version="2.1.12" />
-    <PackageReference Include="Kompression" Version="2.1.7" />
+    <PackageReference Include="Kompression" Version="2.1.8" />
     <PackageReference Include="Konnect" Version="2.1.30" />
     <PackageReference Include="Kryptography" Version="2.1.6" />
   </ItemGroup>

--- a/src/lib/Kompression/Compressions.cs
+++ b/src/lib/Kompression/Compressions.cs
@@ -234,5 +234,10 @@ namespace Kompression
             new CompressionConfigurationBuilder()
                 .Decode.With(() => new SosLz3Decoder())
                 .Encode.With(() => new SosLz3Encoder());
+
+        public static ICompressionConfigurationBuilder LZMA =>
+            new CompressionConfigurationBuilder()
+                .Decode.With(() => new LZMADecoder())
+                .Encode.With(() => new LZMAEncoder());
     }
 }

--- a/src/lib/Kompression/Decoder/LZMADecoder.cs
+++ b/src/lib/Kompression/Decoder/LZMADecoder.cs
@@ -1,0 +1,19 @@
+﻿
+using EasyCompressor;
+using Kompression.Contract.Decoder;
+
+namespace Kompression.Decoder
+{
+    public class LZMADecoder : IDecoder
+    {
+        public void Decode(Stream input, Stream output)
+        {
+            var lzma = new LZMACompressor();
+            lzma.Decompress(input, output);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/lib/Kompression/Encoder/LZMAEncoder.cs
+++ b/src/lib/Kompression/Encoder/LZMAEncoder.cs
@@ -1,0 +1,20 @@
+﻿using EasyCompressor;
+using ICSharpCode.SharpZipLib.Zip.Compression;
+using ICSharpCode.SharpZipLib.Zip.Compression.Streams;
+using Kompression.Contract.Encoder;
+
+namespace Kompression.Encoder
+{
+    public class LZMAEncoder : IEncoder
+    {
+        public void Encode(Stream input, Stream output)
+        {
+            var lzma = new LZMACompressor();
+            lzma.Compress(input, output);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/lib/Kompression/Kompression.Debug.nuspec
+++ b/src/lib/Kompression/Kompression.Debug.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Kompression</id>
-    <version>2.1.7</version>
+    <version>2.1.8</version>
     <description>A library containing all compressions usable by the Kuriimu2 eco-system.</description>
 
     <authors>onepiecefreak;IcySon55</authors>
@@ -18,6 +18,7 @@
 
     <dependencies>
       <group targetFramework="net8.0">
+        <dependency id="EasyCompressor.LZMA" version="2.1.0" />
         <dependency id="K4os.Compression.LZ4.Streams" version="1.3.8" />
         <dependency id="SharpZipLib" version="1.4.2" />
         <dependency id="Komponent" version="2.1.5" />

--- a/src/lib/Kompression/Kompression.csproj
+++ b/src/lib/Kompression/Kompression.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EasyCompressor.LZMA" Version="2.1.0" />
     <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.8" />
     <PackageReference Include="Komponent" Version="2.1.5" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />

--- a/src/lib/Kompression/Kompression.nuspec
+++ b/src/lib/Kompression/Kompression.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Kompression</id>
-    <version>2.1.7</version>
+    <version>2.1.8</version>
     <description>A library containing all compressions usable by the Kuriimu2 eco-system.</description>
 
     <authors>onepiecefreak;IcySon55</authors>
@@ -18,6 +18,7 @@
 
     <dependencies>
       <group targetFramework="net8.0">
+        <dependency id="EasyCompressor.LZMA" version="2.1.0" />
         <dependency id="K4os.Compression.LZ4.Streams" version="1.3.8" />
         <dependency id="SharpZipLib" version="1.4.2" />
         <dependency id="Komponent" version="2.1.5" />


### PR DESCRIPTION
IDX does not work for akb48 games.

The reason for switch to uint is akb1/149 on ps3 has a file over the size of an signed int (the file is 3,452,170,240 bytes in size btw).

EDIT: forgot to mention the ps3 version of APK uses flag 0x300 to identify it as LZMA so I added it to the compressors/decompressors