### PR TITLE
Fixed IMGC Game Format list

### DIFF
--- a/plugins/Level5/plugin_level5/Common/Image/ImageDecoder.cs
+++ b/plugins/Level5/plugin_level5/Common/Image/ImageDecoder.cs
@@ -114,12 +114,12 @@ namespace plugin_level5.Common.Image
                 ["Professor Layton 6"] = 1, // TODO: Unconfirmed
                 ["Professor Layton vs Phoenix Wright"] = 1, // TODO: Unconfirmed
                 ["Time Travelers"] = 1,
+                ["The Snack World TreJarers"] = 1, // TODO: Unconfirmed
                 ["Yo-Kai Watch"] = 1, // TODO: Unconfirmed
                 ["Yo-Kai Watch 2"] = 1, // TODO: Unconfirmed
                 ["Yo-Kai Watch 3"] = 1, // TODO: Unconfirmed
                 ["Yo-Kai Watch Blasters"] = 1, // TODO: Unconfirmed
                 ["Yo-Kai Watch Blasters 2"] = 1, // TODO: Unconfirmed
-                ["Yo-Kai Watch Sangokushi"] = 1, // TODO: Unconfirmed
             };
 
             string[] availableGames = gameMapping.Keys.ToArray();


### PR DESCRIPTION
I removed Yo-kai Watch Sangokushi, a game which doesn't use the format as it was developed by Koei Tecmo in their own engine, and also added The Snack World TreJarers, a game which does use the format